### PR TITLE
'Comparing' chart tooltip - invisible font fix

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1368,6 +1368,10 @@ div#hardwarecontent,div#cameracontent,div#devicecontent,div#logcontent {
     fill: var(--secondary-text-color) !important;
 }
 
+.highcharts-tooltip td {
+    color: var(--secondary-text-color) !important;
+}
+
 .highcharts-tooltip-box {
     fill: var(--main-bg-color);
     fill-opacity: 0.6;


### PR DESCRIPTION
Fixed issue with invisible font in tooltip of 'Comparing' chart