### PR TITLE
Add :root CSS variable defaults to fix first-load rendering

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -16,7 +16,22 @@
 @import url("css/ionicons.min.css");
 
 
-/* vars are now managed in javascript */
+/* Light theme defaults - overridden by JavaScript setColorScheme() on body */
+:root {
+    --main-bg-color: rgb(241,241,241);
+    --main-blue-color: rgb(11,150,205);
+    --main-blue-color-values: 11,150,205;
+    --main-navbar-bg-color: rgb(255,255,255);
+    --main-item-bg-color: rgb(255,255,255);
+    --main-item-color: rgb(26,26,26);
+    --main-text-color: rgb(26,26,26);
+    --secondary-text-color: rgb(109,110,109);
+    --main-border-color: rgb(211,211,211);
+    --main-disabled-color: rgb(211,211,211);
+    --color-error: rgb(199,67,67);
+    --color-success: rgb(91,183,91);
+    --color-warning: rgb(255,140,0);
+}
 
 @font-face {
     font-family: main-font;


### PR DESCRIPTION
## Summary
- Adds `:root` CSS variable declarations with light theme defaults to `custom.css`
- Fixes the theme breaking on first page load when files aren't cached

## Problem
CSS variables (e.g. `--main-bg-color`, `--main-text-color`) are used throughout the theme's CSS but only defined at runtime by JavaScript in `setColorScheme()`. On first load without cache, the async JS hasn't executed when the CSS renders, leaving all `var(--*)` references undefined — causing transparent backgrounds, invisible text, and broken layout. A manual refresh was needed to fix it.

## Solution
Add `:root` declarations with the light theme default values. These render immediately with the stylesheet. When JS loads, `setColorScheme()` sets the same variables as inline styles on `<body>`, which naturally override `:root` due to higher specificity. No JS changes needed.

Dark-mode users will see a brief flash of light-theme colors on first uncached load before JS overrides kick in, which is vastly better than the current broken rendering.

## Test plan
- [ ] Open incognito browser (no cache) and load Domoticz — page should render correctly on first load
- [ ] Verify theme looks identical after JS finishes loading
- [ ] Test with both light and dark themes
- [ ] Test with DevTools Network throttling (Slow 3G) to exaggerate the delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)