### PR TITLE
Fix login page "Remember me" text invisible on new Domoticz login

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1583,6 +1583,9 @@ select.ui-corner-all option {
         transform: translateX(0);
     }
 }
+/* Legacy login page styles (#login) - targets old Domoticz login HTML structure.
+   Can be removed once Domoticz versions before the glass-themed login redesign
+   are no longer supported. */
 #login:before {
     background: linear-gradient(to right, #0bcdc7 0%, #0b96cd 100%);
     text-align: center;
@@ -1683,6 +1686,11 @@ select.ui-corner-all option {
     text-shadow: none;
     border-radius: 2px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
+}
+
+/* New Domoticz login page (glass-themed redesign) */
+.remember-row {
+    color: var(--main-text-color) !important;
 }
 
 .btn-group .btn {


### PR DESCRIPTION
## Summary
- Fixes "Remember me" label being invisible on the new Domoticz glass-themed login page
- Marks old `#login` CSS as legacy for future cleanup

## Problem
Domoticz replaced its login page with a glass-themed design that uses white text (`rgba(255,255,255,0.7)`) on `.remember-row`. The Machinon theme renders the login card with a white background, making the "Remember me" label invisible (white text on white).

## Solution
Add a `.remember-row` color override using the theme's `--main-text-color` variable. The old `#login` selectors are kept for backward compatibility with older Domoticz versions, marked with a legacy comment for future cleanup.

## Before / After

### Before — "Remember me" text invisible
<img width="1280" height="720" alt="login-before" src="https://github.com/user-attachments/assets/ec674a88-d9ad-4e87-86b8-4067d9b183f1" />

### After — "Remember me" text visible
<img width="1280" height="720" alt="login-after" src="https://github.com/user-attachments/assets/86904b44-9e8a-4a75-957a-a724a1f598bc" />

## Test plan
- [ ] Enable login on Domoticz (remove `-nowwwpwd`) and verify "Remember me" text is visible
- [ ] Verify checkbox styling still works correctly
- [ ] Test with both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)