### PR TITLE
Fix empty card on System Setup when updates are disabled

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -76,6 +76,10 @@ a.resetschemebtn {
     border: 1px solid var(--main-item-bg-color);
 }
 
+#settings .row-fluid > div:has(> #SoftwareUpdates.ng-hide) {
+    display: none;
+}
+
 #settings .row-fluid > .span4,
 #settings .row-fluid > .span6,
 #settings .row-fluid > .span12 {


### PR DESCRIPTION
## Summary
- Hides the empty "Software Updates" card wrapper on the System Setup page when `config.UseUpdate` is `false`
- Affects Docker deployments and prebuilt images where in-place updates aren't supported
- Uses CSS `:has()` selector to target the parent `div.span6` only when `#SoftwareUpdates` carries the `ng-hide` class

## Problem
The Domoticz System Setup page has a `div#SoftwareUpdates` with `ng-show="config.UseUpdate"`. When updates are disabled (`UseUpdate: false`), Angular adds `ng-hide` to hide the inner content — but the **parent wrapper div** still receives card styling (background, box-shadow, padding, margin) from the theme CSS, rendering as an empty card next to "Automatic Backup".

### Before — empty card visible
<img width="1280" height="908" alt="settings-setup" src="https://github.com/user-attachments/assets/5e680cf6-d9cb-4991-ac03-b038fdd0fabd" />

### After — empty card hidden
<img width="1280" height="908" alt="settings-setup-after" src="https://github.com/user-attachments/assets/4d9066f6-ce8a-4e80-9c74-bc56700e5ea4" />

## Root cause
The theme styles all `#settings .row-fluid > div` elements as cards. The DOM structure is:
```
.row-fluid > div.span6 > div#SoftwareUpdates.ng-hide  ← hidden by Angular
```
The parent `div.span6` has no content check and renders as an empty card.

## Note for upstream
Ideally the `ng-show="config.UseUpdate"` directive should be on the parent `div.span6` wrapper rather than the inner `#SoftwareUpdates` div. This would fix the empty wrapper for all themes. This PR works around it at the theme level.

## Test plan
- [x] Empty card no longer appears when `UseUpdate` is `false` (Docker)
- [x] "Automatic Backup" card still displays correctly
- [x] All other settings tabs checked for regressions (screenshots taken)
- [x] Existing Playwright e2e tests pass (15/18 — 3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)